### PR TITLE
Update readme.md to render correctly on npmjs.com

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ udpTracker.on('update', function (msg) {
      port: (16 bytes),
      _timeout: timeout for announce try in miliseconds
    }
- ```
+   ```
 
 2. ####udpTracker.announce(event, opts)
 
@@ -101,8 +101,8 @@ following things need to implement.
   - [ ] implement scraping
   - [ ] support IP6
   - [ ] implement extensions
-    * [ ] authentication
-    * [ ] request string
+  - [ ] authentication
+  - [ ] request string
 
 ###Implementation Details
 


### PR DESCRIPTION
My guess is that the display problems on npmjs.com are caused by the different indents for the start and end code-section markers.

npmjs.com uses a http://commonmark.org/ parser, which means it's not _exactly_ the same as github. This may just be that, or it may be a bug in the parser.
